### PR TITLE
Fix mermaid dark mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,6 +119,17 @@ const config = {
         //<meta name="twitter:description" content={description} />
         //<meta name="twitter:image" content={image} />
       ],
+      mermaid: {
+        theme: {
+          light: "base",
+          dark: "base",
+        },
+        options: {
+          themeVariables: {
+            darkMode: false,
+          },
+        },
+      },
     }),
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -121,13 +121,8 @@ const config = {
       ],
       mermaid: {
         theme: {
-          light: "base",
-          dark: "base",
-        },
-        options: {
-          themeVariables: {
-            darkMode: false,
-          },
+          light: "neutral",
+          dark: "neutral",
         },
       },
     }),

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -28,3 +28,12 @@
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+.docusaurus-mermaid-container {
+  background: #ffffff;
+  padding: 1rem;
+}
+
+.docusaurus-mermaid-container > svg {
+  background: #ffffff !important;
+}


### PR DESCRIPTION
I chose you the "neutral" theme

<img width="525" height="366" alt="Screenshot 2026-05-28 at 12 02 14" src="https://github.com/user-attachments/assets/a78011a6-10fb-4fc6-96c5-93b71e2ff2ab" />

There is also "base" theme, but I didn't think the yellow quite worked for the dashed boxes on the white background: 

<img width="610" height="415" alt="Screenshot 2026-05-28 at 11 57 58" src="https://github.com/user-attachments/assets/3496609a-628c-44f1-b476-60778529615e" />

There is also the option to write your own css in the same classes as I put the background color, we could devise a really nice dark mode theme here I'm sure, but it is probably not needed if you are satisfied with just using the white background instead. 
